### PR TITLE
Add attribute to mute on successful client runs.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,6 @@ default['chef_client']['handler']['slack']['username']   = nil
 default['chef_client']['handler']['slack']['icon_url']   = nil
 # OR
 default['chef_client']['handler']['slack']['icon_emoji'] = nil
+
+#  If you don't want to hear about successful runs, set this to true.
+default['chef_client']['handler']['slack']['mute_on_success'] = false

--- a/files/default/slack_handler.rb
+++ b/files/default/slack_handler.rb
@@ -40,9 +40,11 @@ class Chef::Handler::Slack < Chef::Handler
 
   def report
     begin
-      Timeout::timeout(@timeout) do
-        Chef::Log.debug("Sending report to Slack ##{config[:channel]}@#{team}.slack.com")
-        slack_message("Chef client run #{run_status_human_readable} on #{run_status.node.name}")
+      unless config[:mute_on_success] && run_status.success?
+        Timeout::timeout(@timeout) do
+          Chef::Log.debug("Sending report to Slack ##{config[:channel]}@#{team}.slack.com")
+          slack_message("Chef client run #{run_status_human_readable} on #{run_status.node.name}")
+        end
       end
     rescue Exception => e
       Chef::Log.debug("Failed to send message to Slack: #{e.message}")


### PR DESCRIPTION
- I often don't want to read successes if I have a
  lot of nodes, so adding this option to only alert
  on fail will help keep some of the noise down, unless
  of course you just let your client runs fail all
  the time. :D
