### PR TITLE
Fixes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # This repository is deprecated
 
-## Chef Slack Handler has moved here : [rackspace-cookbooks/chef-slack_handler](github.com/rackspace-cookbooks/chef-slack_handler)
+## Chef Slack Handler has moved here : [rackspace-cookbooks/chef-slack_handler](https://github.com/rackspace-cookbooks/chef-slack_handler)
 
 We've not had time to maintain this outside of internal use. In the interest of community, we're turning this initial work over to the rackspace folks.
 


### PR DESCRIPTION
If you don't put http, it appends it to the current URL and breaks everything
